### PR TITLE
run workflow even if no file changes

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -43,8 +43,7 @@ jobs:
         if: steps.filter.outputs.dotnet != 'true'
         run: echo "NOT dotnet file"
   dotnet-build-and-test:
-    needs: paths-filter
-    if: needs.paths-filter.outputs.dotnetChanges == 'true'
+    if: always()
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI workflow configuration to ensure that the dotnet-build-and-test job runs even if there are no changes to the files. This change removes the dependency on the paths-filter job and sets the condition to always run.

* **CI**:
    - Modified the dotnet-build-and-test workflow to run unconditionally, regardless of file changes.

<!-- Generated by sourcery-ai[bot]: end summary -->