### PR TITLE
Python: add Azure Credentials authentication and api_key renewal (#1538)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,6 +45,9 @@ chromadb = "^0.4.0"
 pymilvus = "^2.2.11"
 milvus = "^2.2.11"
 
+[tool.poetry.group.azure_credential.dependencies]
+azure-identity = "^1.13.0"
+
 [tool.poetry.group.weaviate.dependencies]
 weaviate-client = "^3.18.0"
 

--- a/python/samples/kernel-syntax-examples/ad_auth.py
+++ b/python/samples/kernel-syntax-examples/ad_auth.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+
+import semantic_kernel as sk
+from semantic_kernel.connectors.ai import ChatRequestSettings
+from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
+
+
+async def main():
+    _, _, endpoint = sk.azure_openai_settings_from_dot_env(include_api_key=False)
+    service = AzureChatCompletion("gpt-35-turbo", endpoint=endpoint, ad_auth="auto")
+    request_settings = ChatRequestSettings(
+        max_tokens=150,
+        temperature=0.7,
+        top_p=1,
+        frequency_penalty=0.5,
+        presence_penalty=0.5,
+    )
+
+    result = await service.complete_chat_stream_async(
+        "What is the purpose of a rubber duck?", request_settings
+    )
+
+    async for text in result:
+        print(text, end="")  # end = "" to avoid newlines
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_chat_completion.py
@@ -2,14 +2,21 @@
 
 
 from logging import Logger
-from typing import Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
+from semantic_kernel.connectors.ai.chat_request_settings import ChatRequestSettings
+from semantic_kernel.connectors.ai.open_ai.services.azure_credentials_mixin import (
+    AzureCredentialMixin,
+)
 from semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion import (
     OpenAIChatCompletion,
 )
 
+if TYPE_CHECKING:
+    pass
 
-class AzureChatCompletion(OpenAIChatCompletion):
+
+class AzureChatCompletion(OpenAIChatCompletion, AzureCredentialMixin):
     _endpoint: str
     _api_version: str
     _api_type: str
@@ -21,7 +28,7 @@ class AzureChatCompletion(OpenAIChatCompletion):
         api_key: Optional[str] = None,
         api_version: str = "2023-03-15-preview",
         logger: Optional[Logger] = None,
-        ad_auth=False,
+        ad_auth: Union[bool, str, "azure.core.credentials.TokenCredential"] = False,
     ) -> None:
         """
         Initialize an AzureChatCompletion service.
@@ -45,24 +52,42 @@ class AzureChatCompletion(OpenAIChatCompletion):
         :param logger: The logger instance to use. (Optional)
         :param ad_auth: Whether to use Azure Active Directory authentication.
             (Optional) The default value is False.
+            True: use AD with provided api_key
+            'auto': use DefaultAzureCredential() to get key
+            credential: an instance of Azure TokenCredential to get key
+            Using credentials will automate the process of renewing the key
+            upon expiration.
         """
         if not deployment_name:
             raise ValueError("The deployment name cannot be `None` or empty")
-        if not api_key:
-            raise ValueError("The Azure API key cannot be `None` or empty`")
+        if not api_key and isinstance(ad_auth, bool):
+            raise ValueError(
+                "The Azure API key cannot be `None` or empty` when not using Azure Credentials"
+            )
         if not endpoint:
             raise ValueError("The Azure endpoint cannot be `None` or empty")
         if not endpoint.startswith("https://"):
             raise ValueError("The Azure endpoint must start with https://")
 
         self._api_type = "azure_ad" if ad_auth else "azure"
+        self._init_credentials(api_key, ad_auth)
 
         super().__init__(
             deployment_name,
-            api_key,
+            self._api_key,
             api_type=self._api_type,
             api_version=api_version,
             endpoint=endpoint,
             org_id=None,
             log=logger,
         )
+
+    async def _send_chat_request(
+        self,
+        messages: List[Tuple[str, str]],
+        request_settings: ChatRequestSettings,
+        stream: bool,
+    ):
+        self._set_renew_token()
+
+        return await super()._send_chat_request(messages, request_settings, stream)

--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_credentials_mixin.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_credentials_mixin.py
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import time
+from typing import TYPE_CHECKING, Union
+
+TOKEN_URL = "https://cognitiveservices.azure.com/.default"
+
+
+if TYPE_CHECKING:
+    pass
+
+
+class AzureCredentialMixin:
+    _api_key: str
+    _credential = None
+    _api_token = None
+
+    def _init_credentials(
+        self,
+        api_key: str,
+        ad_auth: Union[bool, str, "azure.core.credentials.TokenCredential"],
+    ):
+        if isinstance(ad_auth, bool):
+            self._credential = None
+            self._api_token = None
+            self._api_key = api_key
+
+        elif ad_auth:
+            if api_key:
+                raise ValueError("Cannot provide Azure API key when using credential")
+
+            try:
+                from azure.core.credentials import TokenCredential
+                from azure.identity import DefaultAzureCredential
+
+            except (ImportError, ModuleNotFoundError):
+                raise ImportError(
+                    "Please ensure that azure-identity package is installed to use Azure credentials"
+                )
+
+            if ad_auth == "auto":
+                self._credential = DefaultAzureCredential()
+            elif isinstance(ad_auth, TokenCredential):
+                self._credential = ad_auth
+            else:
+                raise ValueError(
+                    "The ad_auth parameter should be boolean, 'auto' or a TokenCredential"
+                )
+
+            self._set_renew_token()
+
+        else:
+            raise ValueError("Must provide either API key or Azure credentials")
+
+    def _set_renew_token(self):
+        """Sets the api token and key using the credentials.
+        If it is already set and about to expire, renew it.
+        """
+
+        if not self._credential:
+            return
+
+        if not self._api_token or self._api_token.expires_on < int(time.time()) - 60:
+            self._api_token = self._credential.get_token(TOKEN_URL)
+            self._api_key = self._api_token.token
+
+    def set_api_key(self, api_key: str):
+        """Set or update the api_key"""
+        self._api_key = api_key

--- a/python/semantic_kernel/connectors/ai/open_ai/services/azure_text_completion.py
+++ b/python/semantic_kernel/connectors/ai/open_ai/services/azure_text_completion.py
@@ -2,14 +2,23 @@
 
 
 from logging import Logger
-from typing import Optional
+from typing import TYPE_CHECKING, Optional, Union
 
+from semantic_kernel.connectors.ai.complete_request_settings import (
+    CompleteRequestSettings,
+)
+from semantic_kernel.connectors.ai.open_ai.services.azure_credentials_mixin import (
+    AzureCredentialMixin,
+)
 from semantic_kernel.connectors.ai.open_ai.services.open_ai_text_completion import (
     OpenAITextCompletion,
 )
 
+if TYPE_CHECKING:
+    pass
 
-class AzureTextCompletion(OpenAITextCompletion):
+
+class AzureTextCompletion(OpenAITextCompletion, AzureCredentialMixin):
     _endpoint: str
     _api_version: str
     _api_type: str
@@ -21,7 +30,7 @@ class AzureTextCompletion(OpenAITextCompletion):
         api_key: Optional[str] = None,
         api_version: str = "2022-12-01",
         logger: Optional[Logger] = None,
-        ad_auth=False,
+        ad_auth: Union[bool, str, "azure.core.credentials.TokenCredential"] = False,
     ) -> None:
         """
         Initialize an AzureTextCompletion service.
@@ -45,24 +54,39 @@ class AzureTextCompletion(OpenAITextCompletion):
         :param logger: The logger instance to use. (Optional)
         :param ad_auth: Whether to use Azure Active Directory authentication.
             (Optional) The default value is False.
+            True: use AD with provided api_key
+            'auto': use DefaultAzureCredential() to get key
+            credential: an instance of Azure TokenCredential to get key
+            Using credentials will automate the process of renewing the key
+            upon expiration.
         """
         if not deployment_name:
             raise ValueError("The deployment name cannot be `None` or empty")
-        if not api_key:
-            raise ValueError("The Azure API key cannot be `None` or empty`")
+        if not api_key and isinstance(ad_auth, bool):
+            raise ValueError(
+                "The Azure API key cannot be `None` or empty` when not using Azure Credentials"
+            )
         if not endpoint:
             raise ValueError("The Azure endpoint cannot be `None` or empty")
         if not endpoint.startswith("https://"):
             raise ValueError("The Azure endpoint must start with https://")
 
         self._api_type = "azure_ad" if ad_auth else "azure"
+        self._init_credentials(api_key, ad_auth)
 
         super().__init__(
             deployment_name,
-            api_key,
+            self._api_key,
             api_type=self._api_type,
             api_version=api_version,
             endpoint=endpoint,
             org_id=None,
             log=logger,
         )
+
+    async def _send_completion_request(
+        self, prompt: str, request_settings: CompleteRequestSettings, stream: bool
+    ):
+        self._set_renew_token()
+
+        return await super()._send_completion_request(prompt, request_settings, stream)

--- a/python/semantic_kernel/utils/settings.py
+++ b/python/semantic_kernel/utils/settings.py
@@ -23,7 +23,9 @@ def openai_settings_from_dot_env() -> Tuple[str, Optional[str]]:
     return api_key, org_id
 
 
-def azure_openai_settings_from_dot_env(include_deployment=True) -> Tuple[str, str, str]:
+def azure_openai_settings_from_dot_env(
+    include_deployment=True, include_api_key=True
+) -> Tuple[str, str, str]:
     """
     Reads the Azure OpenAI API key and endpoint from the .env file.
 
@@ -42,8 +44,10 @@ def azure_openai_settings_from_dot_env(include_deployment=True) -> Tuple[str, st
     if include_deployment:
         assert deployment, "Azure OpenAI deployment name not found in .env file"
 
-    assert api_key, "Azure OpenAI API key not found in .env file"
-    assert endpoint, "Azure OpenAI endpoint not found in .env file"
+    if include_api_key:
+        assert api_key is not None, "Azure OpenAI API key not found in .env file"
+
+    assert endpoint is not None, "Azure OpenAI endpoint not found in .env file"
 
     return deployment or "", api_key, endpoint
 


### PR DESCRIPTION
### Motivation and Context
When using tokens obtained from Azure AD, they have an expiration, so in long running processes they need to be periodically renewed. Currently there is no way of updating the OpenAI api_key other than accessing the private `_api_key` member.

### Description
<!-- Describe your changes, the overall approach, the underlying design. These notes will help understanding how your code works. Thanks! --> Simplify authentication using Azure AD:
- enable auto login using `DefaultAzureCredential()`
- allow to pass a `TokenCredential`
- automatically renew of token before it expires (when using credentials)
- add method to manually update api_key, without having to access private members. Usefull if not using credentials

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

---------

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:

## Summary by Sourcery

Implement Azure AD authentication with automatic token renewal for AzureChatCompletion and AzureTextCompletion services, allowing the use of DefaultAzureCredential or a custom TokenCredential. Enhance usability by providing a method to manually update the API key. Include a sample script to demonstrate the new authentication feature.

New Features:
- Introduce Azure AD authentication with automatic token renewal for AzureChatCompletion and AzureTextCompletion services.
- Add support for passing a TokenCredential for authentication, enabling seamless integration with Azure AD.

Enhancements:
- Add a method to manually update the API key without accessing private members, improving usability.

Documentation:
- Add a sample script demonstrating the use of Azure AD authentication with the AzureChatCompletion service.