### PR TITLE
Fix repository URL in citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     email: bryanmroe@outlook.com
 version: 1.0.0
 date-released: "2025-06-24"
-url: https://github.com/bryan-roe/semantic-kernel
-repository-code: https://github.com/bryan-roe/semantic-kernel
+url: https://github.com/Bryan-Roe-ai/semantic-kernel
+repository-code: https://github.com/Bryan-Roe-ai/semantic-kernel
 abstract:
   "A research-focused fork of Microsoft's Semantic Kernel, enhanced with AGI\
   \ development tools, \n    performance optimizations, and experimental AI features.\
@@ -34,11 +34,11 @@ preferred-citation:
       orcid: https://orcid.org/0009-0002-4171-1602
   title: "Semantic Kernel Fork: AGI-Focused Enhancements and Research Tools"
   year: 2024
-  url: https://github.com/Bryan-Roe/semantic-kernel
+  url: https://github.com/Bryan-Roe-ai/semantic-kernel
   version: 1.0.0
 identifiers:
   - type: url
-    value: https://github.com/Bryan-Roe/semantic-kernel
+    value: https://github.com/Bryan-Roe-ai/semantic-kernel
 references:
   - type: software
     authors:


### PR DESCRIPTION
## Summary
- correct GitHub repository URL in CITATION.cff

## Testing
- `pytest -q` *(fails: watchdog not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886a61566ec8322954291d25064f30d

## Summary by Sourcery

Bug Fixes:
- Correct the repository URL in CITATION.cff