### PR TITLE
Add agent behavior config

### DIFF
--- a/agent_behavior_config.json
+++ b/agent_behavior_config.json
@@ -7,27 +7,27 @@
   },
   "agents": {
     "agi_file_system": {
-      "verbose_logging": true,
+      "verbose_logging": null,
       "auto_restart": true
     },
     "agi_optimized": {
-      "verbose_logging": false,
+      "verbose_logging": null,
       "auto_restart": true
     },
     "agi_ultra_efficient": {
-      "verbose_logging": false,
+      "verbose_logging": null,
       "auto_restart": true
     },
     "agi_chat": {
-      "verbose_logging": true,
+      "verbose_logging": null,
       "auto_restart": true
     },
     "performance_monitor": {
-      "verbose_logging": true,
+      "verbose_logging": null,
       "auto_restart": false
     },
     "semantic_kernel_agents": {
-      "verbose_logging": false,
+      "verbose_logging": null,
       "auto_restart": true
     }
   }


### PR DESCRIPTION
## Summary
- create `agent_behavior_config.json` to toggle per-agent behaviors like
  verbose logging and auto restart

## Testing
- `pytest -q` *(fails: watchdog not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886a6ef509483229f52379fa9b02163

## Summary by Sourcery

New Features:
- Add agent_behavior_config.json to configure per-agent behaviors such as verbose logging and auto-restart