### PR TITLE
Add agent decision path UI

### DIFF
--- a/decision_path_ui.py
+++ b/decision_path_ui.py
@@ -18,7 +18,7 @@ def build_tree(decisions):
     for d in decisions:
         pid = d['parent_activity_id']
         node = nodes[d['id']]
-        if pid and pid in nodes:
+        if pid is not None and pid in nodes:
             nodes[pid]['children'].append(node)
         else:
             roots.append(node)


### PR DESCRIPTION
## Summary
- implement `decision_path_ui.py` to visualize decision paths from `ai_activities.db`

## Testing
- `pytest -q` *(fails: watchdog missing)*

------
https://chatgpt.com/codex/tasks/task_e_6886a7077f98832283f2190939f04fa9

## Summary by Sourcery

Add a new command-line tool to visualize agent decision paths by extracting decision activities from the SQLite database and generating an interactive HTML hierarchy.

New Features:
- Implement load_decisions, build_tree, and generate_html to fetch decision records, construct a tree structure, and render an expandable HTML view with timestamps.
- Add a CLI with --db and --output options to produce an interactive decision_paths.html file.