### PR TITLE
Add parallel workflow execution

### DIFF
--- a/demo_local_agents.py
+++ b/demo_local_agents.py
@@ -126,7 +126,14 @@ class AGIWorkflowOrchestrator:
         return results
 
     async def process_workflow_parallel(self, workflow: list) -> dict:
-        """Process workflow tasks concurrently across agents"""
+        """
+        Process workflow tasks concurrently across agents.
+
+        Unlike sequential execution, tasks are executed concurrently without any dependency ordering.
+        This means that tasks are scheduled to run simultaneously, and their execution order is not guaranteed.
+        Developers should be aware of potential race conditions if tasks depend on shared resources or have interdependencies.
+        Ensure that workflows are designed to avoid conflicts and unintended behavior due to concurrency.
+        """
         results = {}
         tasks = []
         task_names = []


### PR DESCRIPTION
## Summary
- update local agent demo to run workflows sequentially or in parallel
- add `process_workflow_parallel` for concurrent agent tasks

## Testing
- `python -m pytest -q` *(fails: watchdog not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886a6fca05c8322b72753b6afc0aede

## Summary by Sourcery

Enable parallel execution of workflow steps in the local agent demo by introducing a concurrent processing method and updating the interactive menu accordingly.

New Features:
- Add process_workflow_parallel method to run workflow tasks concurrently

Enhancements:
- Update demo menu to include options for sequential and parallel workflow execution
- Enhance top-level docstring to note parallel workflow support