### PR TITLE
Add AGI command reference

### DIFF
--- a/AGI_COMMANDS.md
+++ b/AGI_COMMANDS.md
@@ -4,7 +4,7 @@ This guide summarizes the main scripts used to interact with the AGI tooling in 
 
 ## AGI Command Line Interface
 
-The `agi_cli.py` script exposes several sub‑commands for performing reasoning and automation tasks.
+The `agi_cli.py` script exposes several sub-commands for performing reasoning and automation tasks.
 
 ```
 python agi_cli.py <command> [args]


### PR DESCRIPTION
## Summary
- document main AGI commands in `AGI_COMMANDS.md`

## Testing
- `pytest --version`
- `pytest test_local_agent.py -q` *(fails: ModuleNotFoundError: No module named 'semantic_kernel')*

------
https://chatgpt.com/codex/tasks/task_e_6886a7beb80883229017518823b1144b

## Summary by Sourcery

Add a comprehensive AGI command reference guide

Documentation:
- Introduce AGI_COMMANDS.md detailing agi_cli.py sub-commands with examples
- Document local_agent_launcher.py commands and interactive menu
- Detail usage of demo_local_agents.py and agi_status_dashboard.py scripts