### PR TITLE
Add benchmark script for agent response times

### DIFF
--- a/demos/performance/benchmark_agent_response.py
+++ b/demos/performance/benchmark_agent_response.py
@@ -74,9 +74,9 @@ async def main() -> None:
     agent = SimpleAGIAgent()
     results = []
     for name, func_name, params in scenarios:
-        duration = await benchmark_scenario(agent, func_name, **params)
+        duration = await benchmark_scenario(agent, func_name, iterations=10, **params)
         results.append((name, duration))
-        print(f"{name:15} : {duration*1000:.2f} ms")
+        print(f"{name:15} : {duration*1000:.2f} ms (average over 10 iterations)")
 
     avg_time = mean(d for _, d in results)
     print(f"\nAverage response time: {avg_time*1000:.2f} ms")


### PR DESCRIPTION
## Summary
- add `benchmark_agent_response.py` script to measure simple agent response times

## Testing
- `pytest 02-ai-workspace/tests/test_ai_workspace_control.py 03-development-tools/tests/test_example.py`
- `python3 demos/performance/benchmark_agent_response.py`

------
https://chatgpt.com/codex/tasks/task_e_6886a6f4e0f4832295a6bf6304ef5731

## Summary by Sourcery

New Features:
- Add benchmark script for measuring response times of AGI agent methods (reasoning, file processing, code generation, task planning).