### PR TITLE
Add agent lifecycle documentation

### DIFF
--- a/docs/AGENT_LIFECYCLE.md
+++ b/docs/AGENT_LIFECYCLE.md
@@ -12,7 +12,7 @@ This document describes the typical lifecycle of a Semantic Kernel agent and how
 
 ## State Management
 
-`InProcessRuntime` exposes methods such as `SaveAgentStateAsync` and `LoadAgentStateAsync` to persist agent state between runs. Unit tests like `AgentStateLifecycleTest` demonstrate saving state from one runtime instance and restoring it in another.
+`InProcessRuntime` (defined in the `SemanticKernel.Runtime` namespace) exposes methods such as `SaveAgentStateAsync` and `LoadAgentStateAsync` to persist agent state between runs. Unit tests like `AgentStateLifecycleTest` (located in `tests/AgentStateLifecycleTest.cs`) demonstrate saving state from one runtime instance and restoring it in another.
 
 ## Runtime Start and Stop
 


### PR DESCRIPTION
## Summary
- document agent lifecycle states and transitions

## Testing
- `pytest -q test_local_agent.py` *(fails: ModuleNotFoundError: No module named 'semantic_kernel')*

------
https://chatgpt.com/codex/tasks/task_e_6886a7164a9483228ada1c605aca8cd5

## Summary by Sourcery

Add a new markdown document outlining the lifecycle stages, state transitions, and runtime behavior of Semantic Kernel agents

Documentation:
- Document agent lifecycle phases (Created, Active, Suspended, Resumed, Deleted) and their state transitions
- Describe methods for persisting and restoring agent state via InProcessRuntime
- Detail runtime start, stop, and idle-wait operations and related error handling