### PR TITLE
Add semantic memory retrieval test

### DIFF
--- a/01-core-implementations/python/tests/unit/memory/test_semantic_memory_retrieval.py
+++ b/01-core-implementations/python/tests/unit/memory/test_semantic_memory_retrieval.py
@@ -16,11 +16,11 @@ class FakeEmbeddingGenerator(EmbeddingGeneratorBase):
         """
         vectors = []
         for text in texts:
-            ascii_sum = sum(ord(c) for c in text)
+            hash_digest = hashlib.sha256(text.encode('utf-8')).hexdigest()
             vec = np.array([
                 len(text),
-                ascii_sum % 10,
-                ascii_sum % 100,
+                int(hash_digest[:8], 16) % 10,
+                int(hash_digest[:16], 16) % 100,
             ], dtype=float)
             vectors.append(vec)
         return np.vstack(vectors)


### PR DESCRIPTION
## Summary
- add unit test to verify semantic memory retrieval

## Testing
- `python 01-core-implementations/python/tests/unit/memory/test_semantic_memory_retrieval.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6886a79400d083228045f0d4e0ce5e79

## Summary by Sourcery

Tests:
- Introduce test_semantic_memory_retrieval.py with FakeEmbeddingGenerator and create_memory helper to test SemanticTextMemory.search accuracy for various queries.