### PR TITLE
Implement alerting via email and Slack

### DIFF
--- a/02-ai-workspace/scripts/ai_workspace_monitor.py
+++ b/02-ai-workspace/scripts/ai_workspace_monitor.py
@@ -477,11 +477,8 @@ class AIWorkspaceMonitor:
 
         try:
             response = requests.post(webhook, json=payload, timeout=5, verify=True)
-            if response.status_code >= 400:
-                logger.error(
-                    f"Slack webhook failed: {response.status_code} {response.text}"
-                )
-        except Exception as e:
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
             logger.error(f"Failed to send Slack alert: {e}")
 
     def log_alert(self, alert: Dict[str, Any]):


### PR DESCRIPTION
## Summary
- expand monitoring script with optional email and Slack alerts
- call new alert functions when alerts are triggered

## Testing
- `pytest -q` *(fails: SystemExit from watcher test)*

------
https://chatgpt.com/codex/tasks/task_e_6886a738b5dc832299bc10649290b8c8

## Summary by Sourcery

Add optional email and Slack alerting to the AI workspace monitor by implementing send_email_alert and send_slack_alert methods and invoking them in the send_alert flow.

New Features:
- Implement send_email_alert method to deliver alerts via SMTP when configured
- Implement send_slack_alert method to post alerts to a Slack webhook when configured
- Trigger email and Slack notifications in the send_alert workflow