### PR TITLE
Add coverage artifacts

### DIFF
--- a/.github/workflows/enhanced-ci-cd.yml
+++ b/.github/workflows/enhanced-ci-cd.yml
@@ -95,6 +95,13 @@ jobs:
           name: dotnet-test-results-${{ matrix.os }}-${{ matrix.configuration }}
           path: ./TestResults/**/*.trx
 
+      - name: Upload Coverage Artifact
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: dotnet-coverage-${{ matrix.os }}-${{ matrix.configuration }}
+          path: ./TestResults/**/coverage.cobertura.xml
+
   # Python Testing with Enhanced Coverage
   python-test:
     name: 🐍 Python Tests
@@ -150,6 +157,13 @@ jobs:
           flags: python-${{ matrix.os }}-${{ matrix.python-version }}
           name: python-coverage
 
+      - name: Upload Coverage Artifact
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: python-coverage-${{ matrix.os }}-${{ matrix.python-version }}
+          path: ./01-core-implementations/python/coverage.xml
+
   # TypeScript Testing
   typescript-test:
     name: 📘 TypeScript Tests
@@ -193,6 +207,13 @@ jobs:
           files: ./01-core-implementations/typescript/coverage/lcov.info
           flags: typescript-${{ matrix.os }}-${{ matrix.node-version }}
           name: typescript-coverage
+
+      - name: Upload Coverage Artifact
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: typescript-coverage-${{ matrix.os }}-${{ matrix.node-version }}
+          path: ./01-core-implementations/typescript/coverage/lcov.info
 
   # Performance Benchmarks
   performance-benchmarks:


### PR DESCRIPTION
## Summary
- upload coverage artifacts for dotnet, python and typescript jobs

## Testing
- `poetry run pytest -k nothing -s` *(fails: invalid pyproject)*

------
https://chatgpt.com/codex/tasks/task_e_6886a76eefd48322a1bcb35a573962af

## Summary by Sourcery

CI:
- Upload coverage artifacts for .NET, Python, and TypeScript test jobs in CI pipeline