### PR TITLE
Add user input simulation example

### DIFF
--- a/docs/simulate_user_input.md
+++ b/docs/simulate_user_input.md
@@ -1,0 +1,11 @@
+# Simulate User Input
+
+`simulate_user_input.py` provides a lightweight way to send a series of test messages to a minimal agent. This allows quick robustness testing without requiring any external dependencies.
+
+## Usage
+
+```bash
+python simulate_user_input.py
+```
+
+The script will run through a predefined set of messages and display the agent's responses.

--- a/simulate_user_input.py
+++ b/simulate_user_input.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Simulate user input for agent robustness testing."""
+
+from datetime import datetime
+
+class SimulatedAgent:
+    """Minimal agent that echoes basic commands."""
+
+    def __init__(self, name: str = "TestAgent"):
+        self.name = name
+        self.start_time = datetime.now()
+        self.task_count = 0
+
+    def process_input(self, message: str) -> str:
+        """Handle a single user message."""
+        self.task_count += 1
+        lower = message.lower()
+        if "hello" in lower:
+            return f"👋 Hello! I'm {self.name}."
+        if "status" in lower:
+            uptime = datetime.now() - self.start_time
+            return f"📊 Running for {uptime}, processed {self.task_count} tasks"
+        if "task" in lower:
+            return f"✅ Task completed: {message}"
+        if "help" in lower:
+            return "🆘 Commands: hello, status, task <desc>, help"
+        return f"🔄 Processing: {message} - Task #{self.task_count} completed"
+
+
+def simulate_user_input(messages):
+    """Send a list of messages to the agent and print responses."""
+    agent = SimulatedAgent()
+    for msg in messages:
+        response = agent.process_input(msg)
+        print(f"User: {msg}")
+        print(f"Agent: {response}\n")
+
+
+if __name__ == "__main__":
+    demo_messages = [
+        "Hello agent!",
+        "status",
+        "task analyze dataset",
+        "help",
+        "<script>alert('test')</script>",
+        "😃 emoji test"
+    ]
+    simulate_user_input(demo_messages)

--- a/stubs/dotenv/__init__.py
+++ b/stubs/dotenv/__init__.py
@@ -1,0 +1,2 @@
+def dotenv_values(path=None):
+    return {}

--- a/stubs/psutil/__init__.py
+++ b/stubs/psutil/__init__.py
@@ -1,0 +1,7 @@
+def cpu_percent(interval=None):
+    return 0.0
+class Mem:
+    percent = 0.0
+
+def virtual_memory():
+    return Mem()


### PR DESCRIPTION
## Summary
- add `simulate_user_input.py` for quick robustness testing
- document how to run the new script
- provide simple `dotenv` and `psutil` stubs so no external dependencies are needed

## Testing
- `python simulate_user_input.py`
- `pytest -q` *(fails: watchdog not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886a779b9e48322a456b0fd652ebc61

## Summary by Sourcery

Add a lightweight user input simulation script with agent example and accompanying documentation and stubs for external dependencies

New Features:
- Add simulate_user_input.py to send test messages to a minimal agent for robustness testing
- Provide stub implementations for psutil and dotenv to avoid external dependencies

Documentation:
- Add simulate_user_input.md with usage instructions for the new script