### PR TITLE
Add automated maintenance workflow

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,20 @@
+name: Repository Maintenance
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  maintenance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run maintenance report
+        run: bash ./enhanced_maintenance.sh report
+      - name: Upload maintenance report
+        uses: actions/upload-artifact@v3
+        with:
+          name: maintenance-report
+          path: MAINTENANCE_REPORT.md
+


### PR DESCRIPTION
## Summary
- automate periodic maintenance tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'watchdog')*

------
https://chatgpt.com/codex/tasks/task_e_6886a7588fb48322b658d3a60559cae0

## Summary by Sourcery

Add a new GitHub Actions workflow to automate periodic repository maintenance tasks

Enhancements:
- Run the maintenance report script and upload the generated report as an artifact

CI:
- Add a weekly scheduled and manually triggered GitHub Actions workflow for maintenance