### PR TITLE
Fix agent launcher environment fallback

### DIFF
--- a/test_local_agent.py
+++ b/test_local_agent.py
@@ -15,6 +15,15 @@ License: MIT
 
 import asyncio
 import logging
+import sys
+from pathlib import Path
+
+# Allow running tests without installing the package
+repo_root = Path(__file__).resolve().parent
+local_package = repo_root / "01-core-implementations" / "python"
+if local_package.exists():
+    sys.path.insert(0, str(local_package))
+
 from semantic_kernel import Kernel
 from semantic_kernel.functions import kernel_function
 


### PR DESCRIPTION
## Summary
- make local agent launcher fall back to system Python
- add repo path to PYTHONPATH in tests

## Testing
- `python3 local_agent_launcher.py list | head`
- `python3 test_local_agent.py` *(fails: ModuleNotFoundError: No module named 'pybars')*

------
https://chatgpt.com/codex/tasks/task_e_6886e923fe1c832284b5f6c627124443

## Summary by Sourcery

Improve agent launcher environment handling by falling back to system Python and local packages when the configured interpreter or semantic_kernel module is unavailable, and update tests to include the repository path in PYTHONPATH

Bug Fixes:
- Add fallback to system Python when configured interpreter is missing
- Convert environment errors for semantic_kernel import to warnings and attempt fallback

Enhancements:
- Introduce python_path attribute to cache and reuse the selected interpreter
- Prepend local '01-core-implementations/python' package to sys.path for local imports
- Unify python_path usage in start_agent to consistently launch agents

Tests:
- Add repository root to PYTHONPATH in test_local_agent.py to resolve imports