### PR TITLE
Fix security for filter evaluation

### DIFF
--- a/01-core-implementations/python/semantic_kernel/connectors/in_memory.py
+++ b/01-core-implementations/python/semantic_kernel/connectors/in_memory.py
@@ -272,6 +272,8 @@ class InMemoryCollection(
             )
         # Walk the AST to look for forbidden names and attribute access
         for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                raise VectorStoreOperationException("Function calls are not allowed in filter expressions.")
             if isinstance(node, ast.Name) and node.id in forbidden_names:
                 raise VectorStoreOperationException(f"Use of '{node.id}' is not allowed in filter expressions.")
             if isinstance(node, ast.Attribute) and node.attr in forbidden_names:

--- a/01-core-implementations/python/tests/unit/connectors/memory/test_in_memory.py
+++ b/01-core-implementations/python/tests/unit/connectors/memory/test_in_memory.py
@@ -181,6 +181,12 @@ async def test_malicious_filter_eval(collection):
         collection._get_filtered_records(type("opt", (), {"filter": "lambda x: eval('2+2')"})())
 
 
+async def test_malicious_filter_function_call(collection):
+    # Should not allow any function call
+    with raises(VectorStoreOperationException):
+        collection._get_filtered_records(type("opt", (), {"filter": "lambda x: int('5')"})())
+
+
 async def test_multiple_filters(collection):
     record1 = {"id": "1", "vector": [1, 2, 3, 4, 5]}
     record2 = {"id": "2", "vector": [5, 4, 3, 2, 1]}


### PR DESCRIPTION
## Summary
- restrict in-memory filter parsing to disallow function calls
- test calling any function is rejected

## Testing
- `pytest --maxfail=1 -k malicious_filter_function_call -c /dev/null` *(fails: watchdog not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea27c3648322b228530a69d4ce73

## Summary by Sourcery

Disallow function calls in in-memory filter parsing by raising an exception on AST Call nodes and add a corresponding unit test to enforce this restriction.

Bug Fixes:
- Disallow function calls in in-memory filter expressions to prevent security vulnerabilities.

Tests:
- Add a test to verify that any function call in filter expressions is rejected.